### PR TITLE
Do not use File.Open for read-only file access.

### DIFF
--- a/MHWNoChunk/Chunk.cs
+++ b/MHWNoChunk/Chunk.cs
@@ -35,7 +35,7 @@ namespace MHWNoChunk
             MetaChunk = new Dictionary<long, long>();
             ChunkOffsetDict = new Dictionary<int, long>();
             string NamePKG = $"{Environment.CurrentDirectory}\\{Path.GetFileNameWithoutExtension(FileInput)}.pkg";
-            Reader = new BinaryReader(File.Open(FileInput, FileMode.Open, FileAccess.Read));
+            Reader = new BinaryReader(File.OpenRead(FileInput));
 
             // Read header
             Reader.BaseStream.Seek(4, SeekOrigin.Begin);
@@ -338,7 +338,7 @@ namespace MHWNoChunk
                 FileInfo keyFileInfo = new FileInfo("chunk.key");
                 try
                 {
-                    BinaryReader keyReader = new BinaryReader(File.Open(keyFileInfo.FullName, FileMode.Open, FileAccess.Read));
+                    BinaryReader keyReader = new BinaryReader(File.OpenRead(keyFileInfo.FullName));
                     int keystart = keyReader.ReadInt32();
                     int keyend = keyReader.ReadInt32();
                     for (int keyitrator = keystart; keyitrator <= keyend; keyitrator++)

--- a/MHWNoChunk/MainWindow.xaml.cs
+++ b/MHWNoChunk/MainWindow.xaml.cs
@@ -166,7 +166,7 @@ namespace MHWNoChunk
 
             try
             {
-                using (BinaryReader Reader = new BinaryReader(File.Open(filename, FileMode.Open))) MagicInputFile = Reader.ReadInt32();
+                using (BinaryReader Reader = new BinaryReader(File.OpenRead(filename))) MagicInputFile = Reader.ReadInt32();
                 if (MagicInputFile == MagicChunk)
                 {
                     if (!CNMode) printlog("Chunk detected，now analyzing...", true);


### PR DESCRIPTION
Used File.OpenRead instead.
(The chunk file is locked by MHW while running MonsterHunterWorld.exe, So MHWNoChunk cannot open the chunk file.)