### PR TITLE
Add (legal) oo2core auto-download option

### DIFF
--- a/MHWNoChunk/MHWNoChunk.csproj
+++ b/MHWNoChunk/MHWNoChunk.csproj
@@ -87,6 +87,9 @@
     <Reference Include="MaterialDesignThemes.Wpf, Version=3.2.0.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
       <HintPath>..\packages\MaterialDesignThemes.3.2.0\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
     </Reference>
+    <Reference Include="SevenZip, Version=19.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LZMA-SDK.19.0.0\lib\net20\SevenZip.dll</HintPath>
+    </Reference>
     <Reference Include="SharpGL, Version=2.4.1.2, Culture=neutral, PublicKeyToken=27fc851303210b27, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpGL.2.4.1.2\lib\net40-client\SharpGL.dll</HintPath>
     </Reference>

--- a/MHWNoChunk/packages.config
+++ b/MHWNoChunk/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="LZMA-SDK" version="19.0.0" targetFramework="net472" />
   <package id="MaterialDesignColors" version="1.2.7" targetFramework="net472" />
   <package id="MaterialDesignThemes" version="3.2.0" targetFramework="net472" />
   <package id="SharpGL" version="2.4.1.2" targetFramework="net472" />


### PR DESCRIPTION
Adds a legal way to automatically download the oo2core_8_win64.dll from a licensed distributor ([Warframe game CDN](https://origin.warframe.com/origin/00000000/Tools/Oodle/x64/final/oo2core_8_win64.dll.3169B48A9A2086E53C4493C03579902C.lzma))

If a user doesn't have the dll when the application is started, it will prompt with this:
![image](https://user-images.githubusercontent.com/8594162/111234328-b0217900-85c4-11eb-8c72-632f2685d95d.png)

This is the same legal workaround / method used by the EGL2 project (https://github.com/WorkingRobot/EGL2/blob/master/checks/oodle_handler.cpp).


This change introduces a new dependency for LZMA decompression, LZMA-SDK, which is compatible with this project's license (both are MIT).
